### PR TITLE
Change ro to rofs.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -83,7 +83,7 @@ AC_DEFINE(OS_RELEASE_FILE, "/etc/os-release",
     [The name of the BMC table of contents file])
 AC_DEFINE(MEDIA_DIR, "/media/",
     [The base dir where all RO partitions are mounted])
-AC_DEFINE(BMC_RO_PREFIX, "/media/ro-",
+AC_DEFINE(BMC_ROFS_PREFIX, "/media/rofs-",
     [The prefix path for the versioned read-only bmc partitions])
 AC_DEFINE(PERSIST_DIR, "/var/lib/obmc/phosphor-bmc-code-mgmt/",
     [The dir where activation data is stored in files])

--- a/item_updater.cpp
+++ b/item_updater.cpp
@@ -156,11 +156,11 @@ void ItemUpdater::processBMCImage()
     for(const auto& iter : fs::directory_iterator(MEDIA_DIR))
     {
         auto activationState = server::Activation::Activations::Active;
-        static const auto BMC_RO_PREFIX_LEN = strlen(BMC_RO_PREFIX);
+        static const auto BMC_RO_PREFIX_LEN = strlen(BMC_ROFS_PREFIX);
 
         // Check if the BMC_RO_PREFIXis the prefix of the iter.path
         if (0 == iter.path().native().compare(0, BMC_RO_PREFIX_LEN,
-                                              BMC_RO_PREFIX))
+                                              BMC_ROFS_PREFIX))
         {
             auto osRelease = iter.path() / OS_RELEASE_FILE;
             if (!fs::is_regular_file(osRelease))


### PR DESCRIPTION
- The bmc read only file systems volumes are named rofs-<versionId>.
- This will fix the issue that prevented item_updater from creating
  the bmc versionIds after a reboot.

Resolves openbmc/openbmc#2267

Change-Id: I26034cbb8928baba8e551aff795f87a0e2c4a262
Signed-off-by: Saqib Khan <khansa@us.ibm.com>